### PR TITLE
Fixed signature markup: move epub:type to <p> and retain bold styling

### DIFF
--- a/src/epub/text/chapter-5.xhtml
+++ b/src/epub/text/chapter-5.xhtml
@@ -38,7 +38,7 @@
 			<blockquote epub:type="z3998:letter">
 				<p>“I hear that a white man is hunting in the Matuku country. This is to warn him to fly over the mountain to Nala. Wambe sends an impi at daybreak to eat him up, because he has hunted before bringing <i xml:lang="sw">hongo</i>. For God’s sake, whoever you are, try to help me. I have been the slave of this devil Wambe for nearly seven years, and am beaten and tortured continually. He murdered all the rest of us, but kept me because I could work iron. Maiwa, his wife, takes this; she is flying to Nala her father because Wambe killed her child. Try to get Nala to attack Wambe; Maiwa can guide them over the mountain. You won’t come for nothing, for the stockade of Wambe’s private kraal is made of elephants’ tusks. For God’s sake, don’t desert me, or I shall kill myself. I can bear this no longer.</p>
 				<footer role="presentation">
-					<p>“<b epub:type="z3998:sender z3998:signature">John Every.</b></p>
+					<p epub:type="z3998:sender z3998:signature">“<b>John Every.</b></p>
 				</footer>
 			</blockquote>
 			<p>“ ‘Great heavens!’ I gasped. ‘Every!⁠—why, it must be my old friend.’ The girl, or rather the woman Maiwa, pointed to the other side of the leaf, where there was more writing. It ran thus⁠—‘I have just heard that the white man is called Macumazahn. If so, it must be my friend Quatermain. Pray Heaven it is, for I know he won’t desert an old chum in such a fix as I am. It isn’t that I’m afraid of dying, I don’t care if I die, but I want to get a chance at Wambe first.’</p>


### PR DESCRIPTION
This PR moves the epub:type attribute from the <b> tag to the <p> tag. This fixes the markup so the sender/signature is correctly marked, and the name stays bold.